### PR TITLE
Add text cleaning, pipeline, hyperparameter tuning, evaluation, and model export

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,14 @@
+import re
+import spacy
+
+nlp = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+
+
+def clean_text(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"http\S+|www\S+", "", text)
+    text = re.sub(r"@\w+|#\w+", "", text)
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    doc = nlp(text)
+    tokens = [token.lemma_ for token in doc if not token.is_stop and token.lemma_.isalnum()]
+    return " ".join(tokens)

--- a/train_model.py
+++ b/train_model.py
@@ -1,41 +1,42 @@
 import pandas as pd
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import train_test_split, GridSearchCV
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import accuracy_score, precision_score, recall_score, confusion_matrix, f1_score
+from sklearn.metrics import classification_report, confusion_matrix
+from sklearn.pipeline import Pipeline
 import joblib
+from preprocess import clean_text
 
 
 def main():
     df = pd.read_csv('text_emotions.csv')
-    X = df['content']
+    X = df['content'].apply(clean_text)
     y = df['sentiment']
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=0)
 
-    vectorizer = TfidfVectorizer(stop_words='english')
-    X_train_vec = vectorizer.fit_transform(X_train)
-    X_test_vec = vectorizer.transform(X_test)
+    model = Pipeline([
+        ('tfidf', TfidfVectorizer(ngram_range=(1, 2), min_df=5, max_df=0.85, max_features=10000)),
+        ('clf', LogisticRegression(solver="liblinear", class_weight="balanced", max_iter=1000)),
+    ])
 
-    model = LogisticRegression(max_iter=1000)
-    model.fit(X_train_vec, y_train)
+    param_grid = {
+        'tfidf__ngram_range': [(1, 1), (1, 2)],
+        'tfidf__max_df': [0.75, 0.85, 1.0],
+        'clf__C': [0.1, 1, 10],
+        'clf__penalty': ['l2'],
+    }
 
-    y_pred = model.predict(X_test_vec)
+    grid = GridSearchCV(model, param_grid, cv=5, scoring="f1_macro", n_jobs=-1, verbose=2)
+    grid.fit(X_train, y_train)
+    model = grid.best_estimator_
 
-    acc = accuracy_score(y_test, y_pred)
-    prec = precision_score(y_test, y_pred, average='macro')
-    recall = recall_score(y_test, y_pred, average='macro')
-    cm = confusion_matrix(y_test, y_pred)
-    f1 = f1_score(y_test, y_pred, average='macro')
+    y_pred = model.predict(X_test)
 
-    print('Accuracy:', f'{acc*100:.3f}')
-    print('Precision:', f'{prec*100:.3f}')
-    print('Recall:', f'{recall*100:.3f}')
-    print('F1-score:', f'{f1*100:.3f}')
-    print('Confusion Matrix:\n', cm)
+    print(classification_report(y_test, y_pred))
+    print(confusion_matrix(y_test, y_pred))
 
-    joblib.dump(model, 'model.pkl')
-    joblib.dump(vectorizer, 'vectorizer.pkl')
+    joblib.dump(model, "best_model.pkl")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- add new preprocessing module for text cleaning
- update training to use text cleaning, sklearn pipeline, and grid search
- print classification metrics and export best model

## Testing
- `python -m py_compile preprocess.py train_model.py`
- `python - <<'PY'
from preprocess import clean_text
print(clean_text('Hello world! Visit http://example.com @user #tag'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687479462b508330bfec008b691f0bde