### PR TITLE
Add spaCy setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ This project trains a Logistic Regression classifier to detect emotions in text 
    pip install -r requirements.txt
    ```
 
-2. Train the model (this creates `model.pkl` and `vectorizer.pkl`):
+2. Download the spaCy English model:
+   ```bash
+   python -m spacy download en_core_web_sm
+   ```
+
+3. Train the model (this creates `model.pkl` and `vectorizer.pkl`):
    ```bash
    python train_model.py
    ```
 
-3. Run the demo app:
+4. Run the demo app:
    ```bash
    streamlit run app.py
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 scikit-learn
 pandas
 joblib
+spacy>=3.0


### PR DESCRIPTION
## Summary
- install spaCy in the requirements
- document downloading the spaCy language model

## Testing
- `pip install -r requirements.txt`
- `python -m spacy download en_core_web_sm`
- `streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_6874834c34588330bf98f62c3be1471d