### PR TITLE
Raise error if model missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ This project trains a Logistic Regression classifier to detect emotions in text 
    ```bash
    python -m spacy download en_core_web_sm
    ```
-3. Train the model (this creates `best_model.pkl`):
+3. **Train the model (this creates `best_model.pkl`):**
    ```bash
    python train_model.py
    ```
+
+   `model.predict()` will raise an error if this file is missing, so be sure
+   to run the training script before using the app or the library functions.
+
 4. Run the demo app:
    ```bash
    streamlit run app.py

--- a/model.py
+++ b/model.py
@@ -21,15 +21,16 @@ def _train_and_serialize():
     model = joblib.load(_MODEL_PATH)
     return model
 
+
 def _load_artifacts():
-    """Load (or if missing, train+load) the model pipeline."""
+    """Load the model pipeline. Raise if artifacts are missing."""
     global _model
 
     if not os.path.exists(_MODEL_PATH):
-        # train_model.py prints metrics and dumps ``best_model.pkl``
-        print("Artifacts not found. Training model now…")
-        _model = _train_and_serialize()
-        return
+        raise FileNotFoundError(
+            "Model artifact 'best_model.pkl' not found. "
+            "Run 'python train_model.py' to train and create it."
+        )
 
     if _model is None:
         _model = joblib.load(_MODEL_PATH)


### PR DESCRIPTION
## Summary
- enforce that `model._load_artifacts()` throws if `best_model.pkl` is absent
- document the need to run `train_model.py` before using the app

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import model
try:
    model.predict('hello')
except FileNotFoundError as e:
    print('caught:', e)
PY
` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687496d4d608833085f415448702444a